### PR TITLE
Create a safe iterator at notify new state

### DIFF
--- a/masmini-common/src/main/java/masmini/Store.kt
+++ b/masmini-common/src/main/java/masmini/Store.kt
@@ -71,7 +71,7 @@ abstract class Store<S> : Closeable {
     @Suppress("UNCHECKED_CAST")
     open fun initialState(): S {
         val type = (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments[0]
-            as Class<S>
+                as Class<S>
         try {
             val constructor = type.getDeclaredConstructor()
             constructor.isAccessible = true
@@ -85,9 +85,7 @@ abstract class Store<S> : Closeable {
         //State mutation should to happen on UI thread
         if (newState != _state) {
             _state = newState
-            listeners.forEach {
-                it(newState)
-            }
+            listeners.toList().forEach { it(newState) }
         }
     }
 

--- a/masmini-common/src/main/java/masmini/Store.kt
+++ b/masmini-common/src/main/java/masmini/Store.kt
@@ -70,8 +70,7 @@ abstract class Store<S> : Closeable {
 
     @Suppress("UNCHECKED_CAST")
     open fun initialState(): S {
-        val type = (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments[0]
-                as Class<S>
+        val type = (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments[0] as Class<S>
         try {
             val constructor = type.getDeclaredConstructor()
             constructor.isAccessible = true

--- a/masmini-common/src/test/kotlin/masmini/StoreTest.kt
+++ b/masmini-common/src/test/kotlin/masmini/StoreTest.kt
@@ -2,6 +2,7 @@ package masmini
 
 import org.amshove.kluent.`should be equal to`
 import org.junit.Test
+import java.io.Closeable
 
 class StoreTest {
 
@@ -43,5 +44,15 @@ class StoreTest {
         closeable.close()
         store.updateState("abc")
         state `should be equal to` ""
+    }
+
+    @Test
+    fun `close listener doesn't throw concurrent exception`() {
+        val store = SampleStore()
+        store.subscribe(hotStart = false) {}
+
+        var subscription: Closeable? = null
+        subscription = store.subscribe(hotStart = false) { subscription?.close() }
+        store.updateState("abc")
     }
 }


### PR DESCRIPTION
When you're iterating offer listener to emit the new state the listener list could change based on the emitted state.

https://github.com/bq/mini-kotlin/pull/11